### PR TITLE
Create symbolic link to /tshock/ServerLog.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@ FROM ubuntu:14.04.4
 
 MAINTAINER Ryan Sheehan <rsheehan@gmail.com>
 
+# Create symbolic link to ServerLog.txt
+RUN mkdir /world /tshock && \
+    touch /world/ServerLog.txt && \
+    ln -s /world/ServerLog.txt /tshock/ServerLog.txt && \
+    rm -rf /world
+
 # Add mono repository
 # Update and install mono and a zip utility
 # fix for favorites.json error


### PR DESCRIPTION
TShock writes a log file directly into the /tshock directory, and the
path is not configurable. Added a symbolic link into /world, so the file
will be created in the mounted volume. This enables the use of the -u
parameter in Docker to run the server as an unprivileged user.