### PR TITLE
Move to mono slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,17 @@ RUN unzip TShock_4.4.0_226_Pre2_Terraria1.4.0.2.zip -d /tshock && \
     rm TShock_4.4.0_226_Pre2_Terraria1.4.0.2.zip && \
     chmod +x /tshock/tshock/TerrariaServer.exe
 
-FROM mono:6.8.0.96
+FROM mono:6.8.0.96-slim
 
 LABEL maintainer="Ryan Sheehan <rsheehan@gmail.com>"
 
 # documenting ports
 EXPOSE 7777 7878
+
+# install nuget to grab tshock dependencies
+RUN apt-get update -y && \
+    apt-get install -y nuget && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
 
 # copy in bootstrap
 COPY bootstrap.sh /tshock/bootstrap.sh
@@ -26,7 +31,7 @@ COPY --from=base /tshock/* /tshock
 RUN mkdir /world && \
     mkdir -p /tshock/logs && \
     mkdir -p /tshock/ServerPlugins &&  \
-    chmod +x /tshock/bootstrap.sh 
+    chmod +x /tshock/bootstrap.sh
     # chmod +x /tshock/TerrariaServer.exe
 
 # Allow for external data

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN mkdir /world && \
     mv /tshock/ServerPlugins /tshock/_ServerPlugins && \
     mkdir -p /tshock/ServerPlugins &&  \
     chmod +x /tshock/bootstrap.sh
-    chmod +x /tshock/TerrariaServer.exe
 
 # Allow for external data
 VOLUME ["/world", "/tshock/logs", "/tshock/ServerPlugins"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,19 +20,18 @@ ENV WORLDPATH=/world
 ENV CONFIGPATH=/world
 ENV LOGPATH=/tshock/logs
 
-# install nuget to grab tshock dependencies
-RUN apt-get update -y && \
-    apt-get install -y nuget && \
-    rm -rf /var/lib/apt/lists/* /tmp/*
-
 # copy in bootstrap
 COPY bootstrap.sh /tshock/bootstrap.sh
 
 # copy game files
 COPY --from=base /tshock/* /tshock
 
-# create directories
-RUN mkdir /world && \
+# install nuget to grab tshock dependencies
+RUN apt-get update -y && \
+    apt-get install -y nuget && \
+    rm -rf /var/lib/apt/lists/* /tmp/* && \
+    # create directories
+    mkdir /world && \
     mkdir /plugins && \
     mkdir -p /tshock/logs && \
     chmod +x /tshock/bootstrap.sh


### PR DESCRIPTION
This PR migrates the final stage to the slim version of mono (uses `debian:slim` instead of `debain`).

This results in an image that sits on disk at 349MB instead of 716MB.

You'll notice that a manual install of `nuget` is done. This is because tshock refuses to work properly without one of (or several of) the dependencies that is brought in when installing `nuget`. I have not pinpointed which dep or deps is/are _actually_ required, yet. It was just easier to let the `nuget` install handle it.