### PR TITLE
Add env var abstraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,13 @@ RUN apk add --update-cache \
 # add the bootstrap file
 COPY bootstrap.sh /tshock/bootstrap.sh
 
+ENV TSHOCKVERSION=v4.4.0-pre6
+ENV TSHOCKZIP=TShock_4.4.0_Pre6_Terraria1.4.0.3.zip
+
 # Download and unpack TShock
-ADD https://github.com/Pryaxis/TShock/releases/download/v4.4.0-pre5/TShock_4.4.0_227_Pre5_Terraria1.4.0.3.zip /
-RUN unzip TShock_4.4.0_227_Pre5_Terraria1.4.0.3.zip -d /tshock && \
-    rm TShock_4.4.0_227_Pre5_Terraria1.4.0.3.zip && \
+ADD https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP /
+RUN unzip $TSHOCKZIP -d /tshock && \
+    rm $TSHOCKZIP && \
     chmod +x /tshock/TerrariaServer.exe && \
     # add executable perm to bootstrap
     chmod +x /tshock/bootstrap.sh


### PR DESCRIPTION
This PR addresses two items:
-  makes TShock version updates slightly more manageable
-  ~updates TShock version to `v4.4.0-pre6`~ version update done in [21bfe8](https://github.com/ryansheehan/terraria/commit/21bfe827bc7a311ec393c4bda9fe4a7579623902)

Notes:
-  it appears that for the latest release, the release number (228) was omitted
-  `pre5` is no longer available