### PR TITLE
Fix TSHOCKZIP file name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --update-cache \
 COPY bootstrap.sh /tshock/bootstrap.sh
 
 ENV TSHOCKVERSION=v4.4.0-pre11
-ENV TSHOCKZIP=TShock_4.4.0_Pre11_Terraria1.4.0.5.zip
+ENV TSHOCKZIP=TShock4.4.0_Pre11_Terraria1.4.0.5.zip
 
 # Download and unpack TShock
 ADD https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP /


### PR DESCRIPTION
Since I was in a hurry to get the latest I tried building the image and the zip path looked wrong.
```
Step 6/18 : ADD https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP /
ADD failed: failed to GET https://github.com/Pryaxis/TShock/releases/download/v4.4.0-pre11/TShock_4.4.0_Pre11_Terraria1.4.0.5.zip with status 404 Not Found: Not Found
```
Managed to get the game running with what I found on https://github.com/Pryaxis/TShock/releases