### PR TITLE
Multi arch image publish

### DIFF
--- a/.github/workflows/build-tshock.yml
+++ b/.github/workflows/build-tshock.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           context: .
           file: tshock/Dockerfile
-          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
           push: true
           tags: |
             ryshe/terraria:tshock-latest

--- a/.github/workflows/build-tshock.yml
+++ b/.github/workflows/build-tshock.yml
@@ -13,12 +13,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Publish TShock
-        uses: elgohr/Publish-Docker-Github-Action@master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
-          name: ryshe/terraria
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          dockerfile: tshock/Dockerfile
-          tags: "tshock-latest"
-          tag_names: true
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: tshock/Dockerfile
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          push: true
+          tags: |
+            ryshe/terraria:tshock-latest

--- a/.github/workflows/build-tshock.yml
+++ b/.github/workflows/build-tshock.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          context: .
+          context: ./tshock
           file: tshock/Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
           push: true

--- a/.github/workflows/build-vanilla.yml
+++ b/.github/workflows/build-vanilla.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          context: .
+          context: ./vanilla
           file: vanilla/Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
           push: true

--- a/.github/workflows/build-vanilla.yml
+++ b/.github/workflows/build-vanilla.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           context: .
           file: vanilla/Dockerfile
-          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
           push: true
           tags: |
             ryshe/terraria:vanilla-latest

--- a/.github/workflows/build-vanilla.yml
+++ b/.github/workflows/build-vanilla.yml
@@ -13,12 +13,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Publish TShock
-        uses: elgohr/Publish-Docker-Github-Action@master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
-          name: ryshe/terraria
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          dockerfile: vanilla/Dockerfile
-          tags: "vanilla-latest"
-          tag_names: true
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: vanilla/Dockerfile
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          push: true
+          tags: |
+            ryshe/terraria:vanilla-latest


### PR DESCRIPTION
I updated github workflow to build multi-arch terraria image by using [docker/build-push-action](https://github.com/docker/build-push-action).
It is useful for who want to build terraria server on raspberry pi like me.

I tested this workflow on my folk repository like following.
It failed because I don't have right to push images to `ryshe/terraria` but everything except that worked.

https://github.com/dragoneena12/terraria/runs/1282401355?check_suite_focus=true
https://github.com/dragoneena12/terraria/runs/1282399860?check_suite_focus=true