### PR TITLE
Update to TShock 4.4.0 Pre-release 15 for Terraria 1.4.1.2

### DIFF
--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -6,13 +6,13 @@ RUN apk add --update-cache \
 # add the bootstrap file
 COPY bootstrap.sh /tshock/bootstrap.sh
 
-ENV TSHOCKVERSION=v4.4.0-pre14
-ENV TSHOCKZIP=TShock4.4.0_Pre14_Terraria1.4.1.2.zip
+ENV TSHOCKVERSION=v4.4.0-pre15
+ENV TSHOCKZIP=TShock4.4.0_Pre15_Terraria1.4.1.2.zip
 
 # Download and unpack TShock
 ADD https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP /
 RUN unzip $TSHOCKZIP -d /tshock && \
-    mv /tshock/TShock4.4.0_Pre14_Terraria1.4.1.2/* /tshock/ && \
+    mv /tshock/TShock4.4.0_Pre15_Terraria1.4.1.2/* /tshock/ && \
     rm $TSHOCKZIP && \
     chmod +x /tshock/TerrariaServer.exe && \
     # add executable perm to bootstrap


### PR DESCRIPTION
Per the TShock team: https://github.com/Pryaxis/TShock/releases/tag/v4.4.0-pre15

IF YOU ARE USING PRE-14 PLEASE UPDATE TO THIS VERSION ASAP

Some debugging was left enabled in pre-14 that will cause unintended tile edits in your worlds.
Please update to this release ASAP