### PR TITLE
Update to TShock to 4.5.0.1

### DIFF
--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -6,13 +6,13 @@ RUN apk add --update-cache \
 # add the bootstrap file
 COPY bootstrap.sh /tshock/bootstrap.sh
 
-ENV TSHOCKVERSION=v4.4.0-pre15
-ENV TSHOCKZIP=TShock4.4.0_Pre15_Terraria1.4.1.2.zip
+ENV TSHOCKVERSION=v4.5.0.1
+ENV TSHOCKZIP=TShock4.5.0.1_Terraria1.4.2.1.zip
 
 # Download and unpack TShock
 ADD https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP /
 RUN unzip $TSHOCKZIP -d /tshock && \
-    mv /tshock/TShock4.4.0_Pre15_Terraria1.4.1.2/* /tshock/ && \
+    mv /tshock/TShock4.5.0.1_Terraria1.4.2.1/* /tshock/ && \
     rm $TSHOCKZIP && \
     chmod +x /tshock/TerrariaServer.exe && \
     # add executable perm to bootstrap


### PR DESCRIPTION
Update to TShock 4.5.0.1, which supports Terraria protocol version 1.4.2.1