### PR TITLE
Update vanilla server download file link

### DIFF
--- a/vanilla/Dockerfile
+++ b/vanilla/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.11.6 AS base
 RUN apk add --update-cache \
     unzip
 
-ENV DL_LINK=https://terraria.org/system/dedicated_servers/archives/000/000/046/original/terraria-server-1423.zip
+ENV DL_LINK=https://terraria.org/api/download/pc-dedicated-server/terraria-server-1423.zip
 ENV DL_VERSION=1423
 ENV DL_FILE=terraria-server-1423.zip
 


### PR DESCRIPTION
I found out that the vanilla server file download url was changed while I was running dockerfile by cloning the source.

> Before
```
https://terraria.org/system/dedicated_servers/archives/000/000/046/original/terraria-server-1423.zip
```

> After
```
https://terraria.org/api/download/pc-dedicated-server/terraria-server-1423.zip
```