### PR TITLE
Copy default config file to vanilla container

### DIFF
--- a/vanilla/Dockerfile
+++ b/vanilla/Dockerfile
@@ -14,7 +14,7 @@ ADD $DL_LINK /$DL_FILE
 
 RUN unzip /$DL_FILE -d /terraria && \
     mv /terraria/$DL_VERSION/Linux/* /terraria-server && \
-    mv /terraria/$DL_VERSION/Windows/serverconfig.txt /terraria-server/serverconfig-default.txt #Linux subfolder does not include any config text file, oddly.
+    mv /terraria/$DL_VERSION/Windows/serverconfig.txt /terraria-server/serverconfig-default.txt && \ #Linux subfolder does not include any config text file, oddly.
     chmod +x /terraria-server/TerrariaServer && \
     chmod +x /terraria-server/TerrariaServer.bin.x86_64
 

--- a/vanilla/Dockerfile
+++ b/vanilla/Dockerfile
@@ -14,6 +14,7 @@ ADD $DL_LINK /$DL_FILE
 
 RUN unzip /$DL_FILE -d /terraria && \
     mv /terraria/$DL_VERSION/Linux/* /terraria-server && \
+    mv /terraria/$DL_VERSION/Windows/serverconfig.txt /terraria-server/serverconfig-default.txt #Linux subfolder does not include any config text file, oddly.
     chmod +x /terraria-server/TerrariaServer && \
     chmod +x /terraria-server/TerrariaServer.bin.x86_64
 

--- a/vanilla/bootstrap.sh
+++ b/vanilla/bootstrap.sh
@@ -5,6 +5,12 @@ echo "world_file_name=$WORLD_FILENAME"
 echo "logpath=$LOGPATH"
 
 WORLD_PATH="/root/.local/share/Terraria/Worlds/$WORLD_FILENAME"
+if [ -z "/config/serverconfig.txt" ]; then
+    echo "Server configuration not found, running with default server configuration."
+    echo "Please ensure your desired serverconfig.txt file is volumed into docker: -v <path_to_config_file>:/config"
+    cp ./serverconfig-default.txt /config/serverconfig.txt
+fi
+
 if [ -z "$WORLD_FILENAME" ]; then
   echo "No world file specified in environment WORLD_FILENAME."
   if [ -z "$@" ]; then
@@ -12,12 +18,12 @@ if [ -z "$WORLD_FILENAME" ]; then
   else
     echo "Running server with command flags: $@"
   fi
-  mono TerrariaServer.exe -logpath "$LOGPATH" "$@"
+  mono TerrariaServer.exe -config "/config/serverconfig.txt" -logpath "$LOGPATH" "$@"
 else
   echo "Environment WORLD_FILENAME specified"
   if [ -f "$WORLD_PATH" ]; then
     echo "Loading to world $WORLD_FILENAME..."
-    mono TerrariaServer.exe -logpath "$LOGPATH" "$@" -world "$WORLD_PATH" "$@"
+    mono TerrariaServer.exe -config "/config/serverconfig.txt" -logpath "$LOGPATH" "$@" -world "$WORLD_PATH" "$@"
   else
     echo "Unable to locate $WORLD_PATH."
     echo "Please make sure your world file is volumed into docker: -v <path_to_world_file>:/root/.local/share/Terraria/Worlds"


### PR DESCRIPTION
For use in bootstrap later.
https://www.linode.com/docs/guides/host-a-terraria-server-on-your-linode/ suggests that serverconfig.txt is still the right format even for Linux, not just Windows.