### PR TITLE
Terraria version update to 1.4.3.6

### DIFF
--- a/mobile/Dockerfile
+++ b/mobile/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.11.6 AS base
+FROM alpine:3.15.0 AS base
 
 RUN apk add --update-cache \
     unzip
 
-ENV DL_LINK=https://terraria.org/server/MobileTerrariaServer.zip
+ENV DL_LINK=https://terraria.org/api/download/mobile-dedicated-server/MobileTerrariaServer.zip
 ENV DL_VERSION=1_4_0_5
 ENV DL_FILE=MobileTerrariaServer.zip
 
@@ -21,7 +21,7 @@ RUN unzip /$DL_FILE -d /terraria-zip && \
     chmod +x /terraria-server/TerrariaServer.bin.x86 && \
     chmod +x /terraria-server/TerrariaServer.bin.x86_64
 
-FROM mono:6.12.0.107
+FROM mono:6.12.0.122-slim
 LABEL maintainer="Ryan Sheehan <rsheehan@gmail.com>"
 
 EXPOSE 7777

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.1 AS base
+FROM alpine:3.15.0 AS base
 
 RUN apk add --update-cache \
     unzip
@@ -6,8 +6,8 @@ RUN apk add --update-cache \
 # add the bootstrap file
 COPY bootstrap.sh /tshock/bootstrap.sh
 
-ENV TSHOCKVERSION=v4.5.15
-ENV TSHOCKZIP=TShock4.5.15_Terraria1.4.3.5.zip
+ENV TSHOCKVERSION=v4.5.16
+ENV TSHOCKZIP=TShock4.5.16_Terraria1.4.3.6.zip
 
 # Download and unpack TShock
 ADD https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP /
@@ -17,7 +17,7 @@ RUN unzip $TSHOCKZIP -d /tshock && \
     # add executable perm to bootstrap
     chmod +x /tshock/bootstrap.sh
 
-FROM mono:6.12.0.107
+FROM mono:6.12.0.122-slim
 
 LABEL maintainer="Ryan Sheehan <rsheehan@gmail.com>"
 

--- a/vanilla/Dockerfile
+++ b/vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11.6 AS base
+FROM alpine:3.15.0 AS base
 
 RUN apk add --update-cache \
     unzip
@@ -6,9 +6,9 @@ RUN apk add --update-cache \
 # add the bootstrap file
 COPY bootstrap.sh /terraria-server/bootstrap.sh
 
-ENV DL_LINK=https://terraria.org/api/download/pc-dedicated-server/terraria-server-1434.zip
-ENV DL_VERSION=1434
-ENV DL_FILE=terraria-server-1434.zip
+ENV DL_LINK=https://terraria.org/api/download/pc-dedicated-server/terraria-server-1436.zip
+ENV DL_VERSION=1436
+ENV DL_FILE=terraria-server-1436.zip
 
 ADD $DL_LINK /$DL_FILE
 
@@ -19,7 +19,7 @@ RUN unzip /$DL_FILE -d /terraria && \
     chmod +x /terraria-server/TerrariaServer && \
     chmod +x /terraria-server/TerrariaServer.bin.x86_64
 
-FROM mono:6.8.0.96-slim
+FROM mono:6.12.0.122-slim
 LABEL maintainer="Ryan Sheehan <rsheehan@gmail.com>"
 
 # documenting ports


### PR DESCRIPTION
## Changes

- Update tshock version to 4.5.16
- Update vanilla version to 1.4.3.6
- Update download URL for mobile server
- Update alpine container to 3.15.0
- Update mono container to 6.12.0.122-slim

> TShock 1.4.3.6 : https://github.com/Pryaxis/TShock/releases/tag/v4.5.16
> Mobile Server Download : https://terraria.org/api/download/mobile-dedicated-server/MobileTerrariaServer.zip