### PR TITLE
Regress to lastest compatible version of mono

### DIFF
--- a/vanilla/Dockerfile
+++ b/vanilla/Dockerfile
@@ -19,7 +19,7 @@ RUN unzip /$DL_FILE -d /terraria && \
     chmod +x /terraria-server/TerrariaServer && \
     chmod +x /terraria-server/TerrariaServer.bin.x86_64
 
-FROM mono:6.12.0.122
+FROM mono:6.10.0.104-slim
 LABEL maintainer="Ryan Sheehan <rsheehan@gmail.com>"
 
 # documenting ports


### PR DESCRIPTION
The Vanilla docker image fails starting with 6.12.X, regardless of slim or not. therefore VANILLA should use 6.10.0.104-slim as that is the last good version of mono for that build. Slim was not causing the issues, and so I re-implemented it to conserve container size. 