### PR TITLE
switch back to -slim for TSHOCK mono

### DIFF
--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -17,7 +17,7 @@ RUN unzip $TSHOCKZIP -d /tshock && \
     # add executable perm to bootstrap
     chmod +x /tshock/bootstrap.sh
 
-FROM mono:6.12.0.122
+FROM mono:6.12.0.122-slim
 
 LABEL maintainer="Ryan Sheehan <rsheehan@gmail.com>"
 


### PR DESCRIPTION
Reverting back to 6.12.0.122-slim since it's known to work fine after testing, vanilla has been tested to have a compatibility issue with the 6.12 branch and will have to stay on 6.10 until the confirmed working on a newer branch. Slim is preferred for TSHOCK due to container size. 