### PR TITLE
Remove '-slim' modifier from TSHOCK's mono version

### DIFF
--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -17,7 +17,8 @@ RUN unzip $TSHOCKZIP -d /tshock && \
     # add executable perm to bootstrap
     chmod +x /tshock/bootstrap.sh
 
-FROM mono:6.12.0.122-slim
+# do not use -slim due to mysql/tshock requirements
+FROM mono:6.12.0.122
 
 LABEL maintainer="Ryan Sheehan <rsheehan@gmail.com>"
 

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -6,8 +6,8 @@ RUN apk add --update-cache \
 # add the bootstrap file
 COPY bootstrap.sh /tshock/bootstrap.sh
 
-ENV TSHOCKVERSION=v4.5.17
-ENV TSHOCKZIP=TShock4.5.17_Terraria_1.4.3.6.zip
+ENV TSHOCKVERSION=v4.5.18
+ENV TSHOCKZIP=TShock4.5.18_Terraria1.4.3.6.zip
 
 # Download and unpack TShock
 ADD https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP /


### PR DESCRIPTION
This patch should resolve https://github.com/ryansheehan/terraria/issues/73

per #73 & fpiesche: Tshock requires 'fsharp' which is not contained in -slim versions of mono. 
going forward slim versions of mono should not be used, so as to maintain mysql compatibility. 

If the ~100mb image savings are needed by a select few, suggest opening a ticket for interest and perhaps creating a tshock-slim version that forgoes complete compatibility for size; however a change to add fsharp to fix the known issue with slim should be introduced before a new 'slim' image is released.