### PR TITLE
Remove duplicate extra arguiments

### DIFF
--- a/vanilla/bootstrap.sh
+++ b/vanilla/bootstrap.sh
@@ -23,7 +23,7 @@ else
   echo "Environment WORLD_FILENAME specified"
   if [ -f "$WORLD_PATH" ]; then
     echo "Loading to world $WORLD_FILENAME..."
-    mono TerrariaServer.exe -config "$CONFIGPATH/$CONFIG_FILENAME" -logpath "$LOGPATH" "$@" -world "$WORLD_PATH" "$@"
+    mono TerrariaServer.exe -config "$CONFIGPATH/$CONFIG_FILENAME" -logpath "$LOGPATH" -world "$WORLD_PATH" "$@"
   else
     echo "Unable to locate $WORLD_PATH."
     echo "Please make sure your world file is volumed into docker: -v <path_to_world_file>:$WORLDPATH"


### PR DESCRIPTION
`$@` is provided twice. When adding extra command arguments to the container, the container fails to start b/c of duplicates.