### PR TITLE
Update to hotfixed vanilla 1.4.4.6

### DIFF
--- a/vanilla/Dockerfile
+++ b/vanilla/Dockerfile
@@ -6,9 +6,9 @@ RUN apk add --update-cache \
 # add the bootstrap file
 COPY bootstrap.sh /terraria-server/bootstrap.sh
 
-ENV DL_LINK=https://terraria.org/api/download/pc-dedicated-server/terraria-server-1446.zip
+ENV DL_LINK=https://terraria.org/api/download/pc-dedicated-server/terraria-server-1446-fixed.zip
 ENV DL_VERSION=1446
-ENV DL_FILE=terraria-server-1446.zip
+ENV DL_FILE=terraria-server-1446-fixed.zip
 
 ADD $DL_LINK /$DL_FILE
 


### PR DESCRIPTION
1.4.4.6 introduced a bug that caused worlds to skip day and enter permanent nighttime. A hotfix was released afterwards with a different server DL link.