### PR TITLE
Added support for TShock on arm64

### DIFF
--- a/.github/workflows/build-tshock.yml
+++ b/.github/workflows/build-tshock.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           context: ./tshock
           file: tshock/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ryshe/terraria:latest

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -1,20 +1,30 @@
 FROM alpine:3.16.3 AS base
 
 RUN apk add --update-cache \
-    unzip
+    curl unzip
 
 # add the bootstrap file
 COPY bootstrap.sh /tshock/bootstrap.sh
 
 ENV TSHOCKVERSION=v5.1.3
-ENV TSHOCKZIP=TShock-5.1.3-for-Terraria-1.4.4.9-linux-x64-Release.zip
 
 # Download and unpack TShock
-ADD https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP /
-RUN unzip $TSHOCKZIP -d /tshock && \    
-    tar -xvf /tshock/*.tar -C /tshock && \
-    rm $TSHOCKZIP && \
-    chmod +x /tshock/TShock.Server && \
+RUN set -eux; \
+    arch="$(apk --print-arch)"; \
+    case "$arch" in \
+        'x86_64') \
+            export TSHOCKZIP='TShock-5.1.3-for-Terraria-1.4.4.9-linux-x64-Release.zip'; \
+            ;; \
+        'aarch64') \
+            export TSHOCKZIP='TShock-5.1.3-for-Terraria-1.4.4.9-linux-arm64-Release.zip'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$arch'."; exit 1 ;; \
+    esac; \
+    curl -L -o /$TSHOCKZIP https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP; \
+    unzip $TSHOCKZIP -d /tshock ; \    
+    tar -xvf /tshock/*.tar -C /tshock ; \
+    rm $TSHOCKZIP ; \
+    chmod +x /tshock/TShock.Server ; \
     # add executable perm to bootstrap
     chmod +x /tshock/bootstrap.sh
 


### PR DESCRIPTION
Hello.
I have tried to make the TShock version compatible with arm64.
However, the Dockerfile around file downloads has been rewritten quite a bit. So it is no longer the same as the other Dockerfile.
If you approve of this commit and are willing to merge it, please confirm that it works to be sure.
Best regards.