### PR TITLE
Allow for the autocreate flag to be specified if WORLD_PATH is not found

### DIFF
--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update -y && \
 
 # copy game files
 COPY --from=base /tshock/ /tshock/
+COPY --from=base /tshock/ServerPlugins /plugins/
 
 # Set working directory to server
 WORKDIR /tshock

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -31,21 +31,21 @@ RUN set -eux; \
 # do not use -slim due to mysql/tshock requirements
 FROM mcr.microsoft.com/dotnet/runtime:6.0
 
-LABEL org.opencontainers.image.authors="Ryan Sheehan <rsheehan@gmail.com>"
-LABEL org.opencontainers.image.url="https://github.com/ryansheehan/terraria"
+LABEL org.opencontainers.image.authors="Logan Saso <logansaso+tech@gmail.com>"
+LABEL org.opencontainers.image.url="https://github.com/logaintech/terraria"
 LABEL org.opencontainers.image.documentation="Dockerfile for Terraria"
-LABEL org.opencontainers.image.source="https://github.com/ryansheehan/terraria/blob/master/tshock/Dockerfile"
+LABEL org.opencontainers.image.source="https://github.com/logansaso/terraria/blob/master/tshock/Dockerfile"
 
 # documenting ports
 EXPOSE 7777 7878
 
 # env used in the bootstrap
-ENV CONFIGPATH=/root/.local/share/Terraria/Worlds
-ENV LOGPATH=/tshock/logs
-ENV WORLD_FILENAME=""
+ENV WORLD_PATH=/root/.local/share/Terraria/Worlds
+ENV CONFIG_PATH=/config
+ENV LOG_PATH=/tshock/logs
 
 # Allow for external data
-VOLUME ["/root/.local/share/Terraria/Worlds", "/tshock/logs", "/plugins"]
+VOLUME ["/root/.local/share/Terraria/Worlds", "/config", "/tshock/logs", "/tshock/ServerPlugins"]
 
 # install nuget to grab tshock dependencies
 RUN apt-get update -y && \
@@ -58,5 +58,4 @@ COPY --from=base /tshock/ /tshock/
 # Set working directory to server
 WORKDIR /tshock
 
-# run the bootstrap, which will copy the TShockAPI.dll before starting the server
 ENTRYPOINT [ "/bin/sh", "bootstrap.sh" ]

--- a/tshock/bootstrap.sh
+++ b/tshock/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "\nBootstrap:\nworld_file_name=$WORLD_FILENAME\nconfigpath=$CONFIGPATH\nlogpath=$LOGPATH\n"
 echo "Copying plugins..."
@@ -17,6 +17,15 @@ fi
 
 WORLD_PATH="/root/.local/share/Terraria/Worlds/$WORLD_FILENAME"
 
+autocreate_flag=false
+for arg in "$@"; do
+    if [ "$arg" = "-autocreate" ]; then
+        autocreate_flag=true
+        break
+    fi
+done
+
+
 if [ -z "$WORLD_FILENAME" ]; then
   echo "No world file specified in environment WORLD_FILENAME."
   if [ -z "$@" ]; then 
@@ -27,11 +36,13 @@ if [ -z "$WORLD_FILENAME" ]; then
   ./TShock.Server -configpath "$CONFIGPATH" -logpath "$LOGPATH" "$@" 
 else
   echo "Environment WORLD_FILENAME specified"
-  if [ -f "$WORLD_PATH" ]; then
-    echo "Loading to world $WORLD_FILENAME..."
-    ./TShock.Server -configpath "$CONFIGPATH" -logpath "$LOGPATH" -world "$WORLD_PATH" "$@" 
+  if [ -f "$WORLD_PATH" ] || [ "$autocreate_flag" = true ]; then
+      echo "Loading to world $WORLD_FILENAME..."
+      ./TShock.Server -configpath "$CONFIGPATH" -logpath "$LOGPATH" -world "$WORLD_PATH" "$@"
   else
-    echo "Unable to locate $WORLD_PATH.\nPlease make sure your world file is volumed into docker: -v <path_to_world_file>:/root/.local/share/Terraria/Worlds"
-    exit 1
+      echo "Unable to locate $WORLD_PATH and -autocreate flag is not set."
+      echo "Please make sure your world file is volumed into docker: -v <path_to_world_file>:/root/.local/share/Terraria/Worlds"
+      echo "Alternatively, use the -autocreate flag to create a new world."
+      exit 1
   fi
 fi

--- a/tshock/bootstrap.sh
+++ b/tshock/bootstrap.sh
@@ -1,48 +1,15 @@
 #!/bin/bash
 
-echo "\nBootstrap:\nworld_file_name=$WORLD_FILENAME\nconfigpath=$CONFIGPATH\nlogpath=$LOGPATH\n"
-echo "Copying plugins..."
-cp -Rfv /plugins/* ./ServerPlugins
-
-if [ $(jq -r '.Settings.StorageType' $CONFIGPATH/config.json) = "mysql" ]; then
-  DATABASE_SERVER=$(jq -r '.Settings.MySqlHost' $CONFIGPATH/config.json | cut -f1 -d':')
-  DATABASE_PORT=$(jq -r '.Settings.MySqlHost' $CONFIGPATH/config.json | cut -f2 -d':')
-  DATABASE_USER_NAME=$(jq -r '.Settings.MySqlUsername' $CONFIGPATH/config.json)
-  DATABASE_USER_PASSWORD=$(jq -r '.Settings.MySqlPassword' $CONFIGPATH/config.json)
+if [ $(jq -r '.Settings.StorageType' $CONFIG_PATH/config.json) = "mysql" ]; then
+  DATABASE_SERVER=$(jq -r '.Settings.MySqlHost' $CONFIG_PATH/config.json | cut -f1 -d':')
+  DATABASE_PORT=$(jq -r '.Settings.MySqlHost' $CONFIG_PATH/config.json | cut -f2 -d':')
+  DATABASE_USER_NAME=$(jq -r '.Settings.MySqlUsername' $CONFIG_PATH/config.json)
+  DATABASE_USER_PASSWORD=$(jq -r '.Settings.MySqlPassword' $CONFIG_PATH/config.json)
   echo "Waiting for the database server."
   while ! mysql -h$DATABASE_SERVER -P$DATABASE_PORT -u$DATABASE_USER_NAME -p$DATABASE_USER_PASSWORD  -e ";" ; do
     sleep 0.1;
   done
 fi
 
-WORLD_PATH="/root/.local/share/Terraria/Worlds/$WORLD_FILENAME"
-
-autocreate_flag=false
-for arg in "$@"; do
-    if [ "$arg" = "-autocreate" ]; then
-        autocreate_flag=true
-        break
-    fi
-done
-
-
-if [ -z "$WORLD_FILENAME" ]; then
-  echo "No world file specified in environment WORLD_FILENAME."
-  if [ -z "$@" ]; then 
-    echo "Running server setup..."
-  else
-    echo "Running server with command flags: $@"
-  fi
-  ./TShock.Server -configpath "$CONFIGPATH" -logpath "$LOGPATH" "$@" 
-else
-  echo "Environment WORLD_FILENAME specified"
-  if [ -f "$WORLD_PATH" ] || [ "$autocreate_flag" = true ]; then
-      echo "Loading to world $WORLD_FILENAME..."
-      ./TShock.Server -configpath "$CONFIGPATH" -logpath "$LOGPATH" -world "$WORLD_PATH" "$@"
-  else
-      echo "Unable to locate $WORLD_PATH and -autocreate flag is not set."
-      echo "Please make sure your world file is volumed into docker: -v <path_to_world_file>:/root/.local/share/Terraria/Worlds"
-      echo "Alternatively, use the -autocreate flag to create a new world."
-      exit 1
-  fi
-fi
+echo "./TShock.Server -config \"$CONFIG_PATH/serverconfig.txt\" -configpath \"$CONFIG_PATH\" -logpath \"$LOG_PATH\" -worldpath /root/.local/share/Terraria/Worlds/ \"$@\""
+./TShock.Server -config "$CONFIG_PATH/serverconfig.txt" -configpath "$CONFIG_PATH" -logpath "$LOG_PATH" -worldpath /root/.local/share/Terraria/Worlds/ "$@"

--- a/tshock/bootstrap.sh
+++ b/tshock/bootstrap.sh
@@ -11,5 +11,10 @@ if [ $(jq -r '.Settings.StorageType' $CONFIG_PATH/config.json) = "mysql" ]; then
   done
 fi
 
+if [ -z "$(ls -A /tshock/ServerPlugins)" ]; then
+  echo "Copying plugins..."
+  cp /plugins/* /tshock/ServerPlugins
+fi
+
 echo "./TShock.Server -config \"$CONFIG_PATH/serverconfig.txt\" -configpath \"$CONFIG_PATH\" -logpath \"$LOG_PATH\" -worldpath /root/.local/share/Terraria/Worlds/ \"$@\""
 ./TShock.Server -config "$CONFIG_PATH/serverconfig.txt" -configpath "$CONFIG_PATH" -logpath "$LOG_PATH" -worldpath /root/.local/share/Terraria/Worlds/ "$@"


### PR DESCRIPTION
The server can autocreate a world if the path is set, but the file doesn't exist. This PR checks for that flag in the args when deciding to error for a missing worldfile.