### PR TITLE
Update to TShock v5.2.3 and improve TShock fetch logic.

### DIFF
--- a/mobile/Dockerfile
+++ b/mobile/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3 AS base
+FROM alpine:3.21 AS base
 
 RUN apk add --update-cache \
     unzip
@@ -21,7 +21,7 @@ RUN unzip $DL_FILE && \
     chmod +x ./terraria-server/TerrariaServer && \
     chmod +x ./terraria-server/TerrariaServer.bin.x86_64
 
-FROM mono:6.12.0.182
+FROM mono:6.12
 
 LABEL org.opencontainers.image.authors="Ryan Sheehan <rsheehan@gmail.com>"
 LABEL org.opencontainers.image.url="https://github.com/ryansheehan/terraria"

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -20,18 +20,22 @@ ENV TSHOCKVERSION=v5.2.2
 RUN set -eux; \
     arch="$(apk --print-arch)"; \
     case "$arch" in \
-    'x86_64') \
-      export TSHOCKZIP='TShock-5.2.2-for-Terraria-1.4.4.9-linux-amd64-Release.zip' \
-      ;; \
-    'aarch64') \
-      export TSHOCKZIP='TShock-5.2.2-for-Terraria-1.4.4.9-linux-arm64-Release.zip' \
-      ;; \
+    'x86_64') arch_suffix="amd64" ;; \
+    'aarch64') arch_suffix="arm64" ;; \
     *) \
-      echo >&2 "error: unsupported architecture '$arch'." \
+      echo >&2 "error: unsupported architecture '$arch'."; \
       exit 1 \
       ;; \
     esac; \
-    curl -L -o /$TSHOCKZIP "https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP"; \
+    # Get the asset list from GitHub API
+    if [ "${TSHOCKVERSION}" = "latest" ]; then \
+        RELEASE_URL="https://api.github.com/repos/Pryaxis/TShock/releases/latest"; \
+    else \
+        RELEASE_URL="https://api.github.com/repos/Pryaxis/TShock/releases/tags/$TSHOCKVERSION"; \
+    fi; \
+    TSHOCKURL=$(curl -s $RELEASE_URL | grep browser_download_url | grep "linux-$arch_suffix-Release.zip" | cut -d '"' -f 4); \
+    TSHOCKZIP=$(basename $TSHOCKURL); \
+    curl -L -o "/$TSHOCKZIP" "$TSHOCKURL"; \
     unzip "$TSHOCKZIP" -d "/tshock"; \
     tar -xvf "/tshock/"*.tar -C "/tshock"; \
     rm "$TSHOCKZIP"; \

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -1,5 +1,11 @@
 FROM alpine:3.21.0 AS base
 
+# Available environment variables:
+# TSHOCKVERSION="v5.2.2"
+# WORLD_FILENAME="world.wld"
+# CONFIGPATH="/tshock/config"
+# LOGPATH="/tshock/logs"
+
 RUN apk add --update-cache \
     curl unzip
 

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -1,3 +1,4 @@
+ARG DOTNETRUNTIME_VERSION=6.0
 FROM alpine:3.21 AS base
 
 # Available environment variables:
@@ -44,7 +45,7 @@ RUN set -eux; \
     chmod +x "/tshock/bootstrap.sh"
 
 # do not use -slim due to mysql/tshock requirements
-FROM mcr.microsoft.com/dotnet/runtime:6.0
+FROM mcr.microsoft.com/dotnet/runtime:${DOTNETRUNTIME_VERSION} AS runtime
 
 LABEL org.opencontainers.image.authors="Ryan Sheehan <rsheehan@gmail.com>"
 LABEL org.opencontainers.image.url="https://github.com/ryansheehan/terraria"

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --update-cache \
 # add the bootstrap file
 COPY bootstrap.sh /tshock/bootstrap.sh
 
-ENV TSHOCKVERSION=v5.2.2
+ENV TSHOCKVERSION=v5.2.3
 
 # Download and unpack TShock
 # x86_64:   https://github.com/Pryaxis/TShock/releases/download/v5.2.2/TShock-5.2.2-for-Terraria-1.4.4.9-linux-amd64-Release.zip

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -15,26 +15,29 @@ COPY bootstrap.sh /tshock/bootstrap.sh
 ENV TSHOCKVERSION=v5.2.2
 
 # Download and unpack TShock
-# https://github.com/Pryaxis/TShock/releases/download/v5.2.2/TShock-5.2.2-for-Terraria-1.4.4.9-linux-amd64-Release.zip
-# https://github.com/Pryaxis/TShock/releases/download/v5.2.2/TShock-5.2.2-for-Terraria-1.4.4.9-linux-arm64-Release.zip
+# x86_64:   https://github.com/Pryaxis/TShock/releases/download/v5.2.2/TShock-5.2.2-for-Terraria-1.4.4.9-linux-amd64-Release.zip
+# aarch64:  https://github.com/Pryaxis/TShock/releases/download/v5.2.2/TShock-5.2.2-for-Terraria-1.4.4.9-linux-arm64-Release.zip
 RUN set -eux; \
     arch="$(apk --print-arch)"; \
     case "$arch" in \
-        'x86_64') \
-            export TSHOCKZIP='TShock-5.2.2-for-Terraria-1.4.4.9-linux-amd64-Release.zip'; \
-            ;; \
-        'aarch64') \
-            export TSHOCKZIP='TShock-5.2.2-for-Terraria-1.4.4.9-linux-arm64-Release.zip'; \
-            ;; \
-        *) echo >&2 "error: unsupported architecture '$arch'."; exit 1 ;; \
+    'x86_64') \
+      export TSHOCKZIP='TShock-5.2.2-for-Terraria-1.4.4.9-linux-amd64-Release.zip' \
+      ;; \
+    'aarch64') \
+      export TSHOCKZIP='TShock-5.2.2-for-Terraria-1.4.4.9-linux-arm64-Release.zip' \
+      ;; \
+    *) \
+      echo >&2 "error: unsupported architecture '$arch'." \
+      exit 1 \
+      ;; \
     esac; \
-    curl -L -o /$TSHOCKZIP https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP; \
-    unzip $TSHOCKZIP -d /tshock ; \    
-    tar -xvf /tshock/*.tar -C /tshock ; \
-    rm $TSHOCKZIP ; \
-    chmod +x /tshock/TShock.Server ; \
+    curl -L -o /$TSHOCKZIP "https://github.com/Pryaxis/TShock/releases/download/$TSHOCKVERSION/$TSHOCKZIP"; \
+    unzip "$TSHOCKZIP" -d "/tshock"; \
+    tar -xvf "/tshock/"*.tar -C "/tshock"; \
+    rm "$TSHOCKZIP"; \
+    chmod +x "/tshock/TShock.Server"; \
     # add executable perm to bootstrap
-    chmod +x /tshock/bootstrap.sh
+    chmod +x "/tshock/bootstrap.sh"
 
 # do not use -slim due to mysql/tshock requirements
 FROM mcr.microsoft.com/dotnet/runtime:6.0

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21.0 AS base
+FROM alpine:3.21 AS base
 
 # Available environment variables:
 # TSHOCKVERSION="v5.2.2"

--- a/tshock/bootstrap.sh
+++ b/tshock/bootstrap.sh
@@ -8,15 +8,14 @@ if [ -z "$(ls -A /tshock/ServerPlugins)" ]; then
   cp /plugins/* /tshock/ServerPlugins
 fi
 
-
 if [ $(jq -r '.Settings.StorageType' $CONFIGPATH/config.json) = "mysql" ]; then
   DATABASE_SERVER=$(jq -r '.Settings.MySqlHost' $CONFIGPATH/config.json | cut -f1 -d':')
   DATABASE_PORT=$(jq -r '.Settings.MySqlHost' $CONFIGPATH/config.json | cut -f2 -d':')
   DATABASE_USER_NAME=$(jq -r '.Settings.MySqlUsername' $CONFIGPATH/config.json)
   DATABASE_USER_PASSWORD=$(jq -r '.Settings.MySqlPassword' $CONFIGPATH/config.json)
   echo "Waiting for the database server."
-  while ! mysql -h$DATABASE_SERVER -P$DATABASE_PORT -u$DATABASE_USER_NAME -p$DATABASE_USER_PASSWORD  -e ";" ; do
-    sleep 0.1;
+  while ! mysql -h$DATABASE_SERVER -P$DATABASE_PORT -u$DATABASE_USER_NAME -p$DATABASE_USER_PASSWORD -e ";"; do
+    sleep 0.1
   done
 fi
 
@@ -24,30 +23,29 @@ WORLD_PATH="/root/.local/share/Terraria/Worlds/$WORLD_FILENAME"
 
 autocreate_flag=false
 for arg in "$@"; do
-    if [ "$arg" = "-autocreate" ]; then
-        autocreate_flag=true
-        break
-    fi
+  if [ "$arg" = "-autocreate" ]; then
+    autocreate_flag=true
+    break
+  fi
 done
-
 
 if [ -z "$WORLD_FILENAME" ]; then
   echo "No world file specified in environment WORLD_FILENAME."
-  if [ -z "$@" ]; then 
+  if [ -z "$@" ]; then
     echo "Running server setup..."
   else
     echo "Running server with command flags: $@"
   fi
-  ./TShock.Server -configpath "$CONFIGPATH" -logpath "$LOGPATH" "$@" 
+  ./TShock.Server -configpath "$CONFIGPATH" -logpath "$LOGPATH" "$@"
 else
   echo "Environment WORLD_FILENAME specified"
   if [ -f "$WORLD_PATH" ] || [ "$autocreate_flag" = true ]; then
-      echo "Loading to world $WORLD_FILENAME..."
-      ./TShock.Server -configpath "$CONFIGPATH" -logpath "$LOGPATH" -world "$WORLD_PATH" "$@"
+    echo "Loading to world $WORLD_FILENAME..."
+    ./TShock.Server -configpath "$CONFIGPATH" -logpath "$LOGPATH" -world "$WORLD_PATH" "$@"
   else
-      echo "Unable to locate $WORLD_PATH and -autocreate flag is not set."
-      echo "Please make sure your world file is volumed into docker: -v <path_to_world_file>:/root/.local/share/Terraria/Worlds"
-      echo "Alternatively, use the -autocreate flag to create a new world."
-      exit 1
+    echo "Unable to locate $WORLD_PATH and -autocreate flag is not set."
+    echo "Please make sure your world file is volumed into docker: -v <path_to_world_file>:/root/.local/share/Terraria/Worlds"
+    echo "Alternatively, use the -autocreate flag to create a new world."
+    exit 1
   fi
 fi

--- a/vanilla/Dockerfile
+++ b/vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3 AS base
+FROM alpine:3.21 AS base
 
 RUN apk add --update-cache \
     unzip
@@ -19,7 +19,7 @@ RUN unzip /$DL_FILE -d /terraria && \
     chmod +x /terraria-server/TerrariaServer && \
     chmod +x /terraria-server/TerrariaServer.bin.x86_64
 
-FROM mono:6.10.0.104-slim
+FROM mono:6.10-slim
 
 LABEL org.opencontainers.image.authors="Ryan Sheehan <rsheehan@gmail.com>"
 LABEL org.opencontainers.image.url="https://github.com/ryansheehan/terraria"

--- a/vanilla/bootstrap.sh
+++ b/vanilla/bootstrap.sh
@@ -6,9 +6,9 @@ echo "logpath=$LOGPATH"
 
 WORLD_PATH="$WORLDPATH/$WORLD_FILENAME"
 if [ ! -f "$CONFIGPATH/$CONFIG_FILENAME" ]; then
-    echo "Server configuration not found, running with default server configuration."
-    echo "Please ensure your desired $CONFIG_FILENAME file is volumed into docker: -v <path_to_config_file>:/$CONFIGPATH"
-    cp ./serverconfig-default.txt $CONFIGPATH/$CONFIG_FILENAME
+  echo "Server configuration not found, running with default server configuration."
+  echo "Please ensure your desired $CONFIG_FILENAME file is volumed into docker: -v <path_to_config_file>:/$CONFIGPATH"
+  cp ./serverconfig-default.txt $CONFIGPATH/$CONFIG_FILENAME
 fi
 
 if [ -z "$WORLD_FILENAME" ]; then
@@ -30,4 +30,3 @@ else
     exit 1
   fi
 fi
-


### PR DESCRIPTION
- Added a dynamic `DOTNETRUNTIME_VERSION` argument in `tshock/Dockerfile` to allow flexibility in specifying the .NET runtime version (upcoming TShock release will move to .NET 9).
- Updated logic in `tshock/Dockerfile` to dynamically fetch the latest or specific TShock release using the GitHub API, which allows the TShock version to be specified dynamically at runtime.
- Updated default targeted TShock version to [v5.2.3](https://github.com/Pryaxis/TShock/releases/tag/v5.2.3).
- Updated the Alpine Linux base image from `3.17.3` to `3.21` in `mobile/Dockerfile` and `vanilla/Dockerfile`, and from `3.21.0` to `3.21` in `tshock/Dockerfile`. Previous versions were flagged due to vulnerabilities.
- Updated Mono versions to (`6.12` and `6.10-slim`) in `mobile/Dockerfile` and `vanilla/Dockerfile`. Previous versions were flagged due to vulnerabilities.
- Format shell scripts with `shell-format`.
