### PR TITLE
Fixed oversight in pr #175

### DIFF
--- a/vanilla/bootstrap.sh
+++ b/vanilla/bootstrap.sh
@@ -23,7 +23,7 @@ else
   echo "Environment WORLD_FILENAME specified"
   if [ -f "$WORLD_PATH" ]; then
     echo "Loading to world $WORLD_FILENAME..."    
-    ./TerrariaServer.exe -config "$CONFIGPATH/$CONFIG_FILENAME" -logpath "$LOGPATH" -world "$WORLD_PATH" "$@"
+    ./TerrariaServer -config "$CONFIGPATH/$CONFIG_FILENAME" -logpath "$LOGPATH" -world "$WORLD_PATH" "$@"
   else
     echo "Unable to locate $WORLD_PATH."
     echo "Please make sure your world file is volumed into docker: -v <path_to_world_file>:$WORLDPATH"


### PR DESCRIPTION
Forgot to remove the .exe in the binary name, causing the following error when running the server with WORLD_FILENAME env variable:  "bootstrap.sh: 26: ./TerrariaServer.exe: Exec format error"