### PR TITLE
Update TShock to v6.1.0 for Terraria 1.4.5.6

### DIFF
--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -1,4 +1,4 @@
-ARG DOTNETRUNTIME_VERSION=6.0
+ARG DOTNETRUNTIME_VERSION=9.0
 FROM alpine:3.23 AS base
 
 # Available environment variables:

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -16,12 +16,12 @@ COPY bootstrap.sh /tshock/bootstrap.sh
 ENV TSHOCKVERSION=v6.1.0
 
 # Download and unpack TShock
-# x86_64:   https://github.com/Pryaxis/TShock/releases/download/v6.1.0/TShock-6.1.0-for-Terraria-1.4.5.6-linux-amd64-Release.zip
+# x86_64:   https://github.com/Pryaxis/TShock/releases/download/v6.1.0/TShock-6.1.0-for-Terraria-1.4.5.6-linux-x64-Release.zip
 # aarch64:  https://github.com/Pryaxis/TShock/releases/download/v6.1.0/TShock-6.1.0-for-Terraria-1.4.5.6-linux-arm64-Release.zip
 RUN set -eux; \
     arch="$(apk --print-arch)"; \
     case "$arch" in \
-    'x86_64') arch_suffix="amd64" ;; \
+    'x86_64') arch_suffix="x64" ;; \
     'aarch64') arch_suffix="arm64" ;; \
     *) \
       echo >&2 "error: unsupported architecture '$arch'."; \

--- a/tshock/Dockerfile
+++ b/tshock/Dockerfile
@@ -1,8 +1,8 @@
 ARG DOTNETRUNTIME_VERSION=6.0
-FROM alpine:3.21 AS base
+FROM alpine:3.23 AS base
 
 # Available environment variables:
-# TSHOCKVERSION="v5.2.4"
+# TSHOCKVERSION="v6.1.0"
 # WORLD_FILENAME="world.wld"
 # CONFIGPATH="/tshock/config"
 # LOGPATH="/tshock/logs"
@@ -13,11 +13,11 @@ RUN apk add --no-cache \
 # add the bootstrap file
 COPY bootstrap.sh /tshock/bootstrap.sh
 
-ENV TSHOCKVERSION=v5.2.4
+ENV TSHOCKVERSION=v6.1.0
 
 # Download and unpack TShock
-# x86_64:   https://github.com/Pryaxis/TShock/releases/download/v5.2.4/TShock-5.2.4-for-Terraria-1.4.4.9-linux-amd64-Release.zip
-# aarch64:  https://github.com/Pryaxis/TShock/releases/download/v5.2.4/TShock-5.2.4-for-Terraria-1.4.4.9-linux-arm64-Release.zip
+# x86_64:   https://github.com/Pryaxis/TShock/releases/download/v6.1.0/TShock-6.1.0-for-Terraria-1.4.5.6-linux-amd64-Release.zip
+# aarch64:  https://github.com/Pryaxis/TShock/releases/download/v6.1.0/TShock-6.1.0-for-Terraria-1.4.5.6-linux-arm64-Release.zip
 RUN set -eux; \
     arch="$(apk --print-arch)"; \
     case "$arch" in \


### PR DESCRIPTION
Hello! 

TShock v6 has been released with support for the current version of Terraria.

https://github.com/Pryaxis/TShock/releases/tag/v6.1.0