### PR TITLE
Improve Docker compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ The stdin_open and tty options are a workaround to running the container in deta
 (Note for Podman users: Ensure to add the :Z flag to the volume to give the container access to the volume.)
 
 ```yaml
-
-version: "3"
 services:
   terraria:
     container_name: terraria
@@ -174,11 +172,11 @@ services:
     tty: true # docker run -t
     environment:
       - WORLD_FILENAME=world.wld
-      - CONFIGPATH=config.json
     ports:
       - 7777:7777
     volumes:
-      - <world-dir-location>:/root/.local/share/Terraria/Worlds
+      - <path-to-world-dir>:/root/.local/share/Terraria/Worlds
+      - <path-to-serverconfig.txt>:/config/serverconfig.txt
     restart: unless-stopped
 
 ```


### PR DESCRIPTION
IMHO current example is a bit confusing. Seems like CONFIG_PATH was supposed to be CONFIG_FILENAME, but also no mount is specified.

Removed version as suggested by Docker.